### PR TITLE
[IMP][114575] Add a signed value in origins

### DIFF
--- a/onsp_co2/models/account_move_line.py
+++ b/onsp_co2/models/account_move_line.py
@@ -148,8 +148,9 @@ class AccountMoveLine(models.Model):
         return self.move_id.company_id
 
 
-
-
+    def get_carbon_sign(self) -> int:
+        self.ensure_one()
+        return -1 if self.move_id.is_inbound(include_receipts=True) else 1
 
     # --- Modular methods ---
     # --- ACCOUNT ---

--- a/onsp_co2/views/account_move.xml
+++ b/onsp_co2/views/account_move.xml
@@ -36,6 +36,7 @@
                     <field name="carbon_debit" optional="hide" sum="Total CO2 Debit" digits="[13,2]" />
                     <field name="carbon_credit" optional="hide" sum="Total CO2 Credit" digits="[13,2]" />
                     <field name="carbon_balance" optional="show" sum="Total CO2 Balance" digits="[13,2]" />
+                    <button type="object" name="action_see_carbon_origin" icon="fa-question-circle" title="See CO2 value origin" />
                     <field name="carbon_origin_json" invisible="1" force_save="1" />
                     <field name="carbon_currency_id" invisible="1" />
                 </xpath>

--- a/onsp_co2/views/account_move_line.xml
+++ b/onsp_co2/views/account_move_line.xml
@@ -13,6 +13,7 @@
                 <field name="carbon_debit" sum="Total CO2 Debit" optional="hide" readonly="1" digits="[13,2]" />
                 <field name="carbon_credit" sum="Total CO2 Credit" optional="hide" readonly="1" digits="[13,2]" />
                 <field name="carbon_debt" sum="Total CO2 Debt" optional="hide" readonly="1" digits="[13,2]" />
+                <button type="object" name="action_see_carbon_origin" icon="fa-question-circle" title="See CO2 value origin" />
                 <field name="carbon_currency_id" invisible="1"/>
             </xpath>
         </field>

--- a/onsp_co2/views/carbon_line_origin.xml
+++ b/onsp_co2/views/carbon_line_origin.xml
@@ -6,11 +6,13 @@
             <field name="name">carbon.line.origin.tree</field>
             <field name="model">carbon.line.origin</field>
             <field name="arch" type="xml">
-                <tree create="0" delete="0" edit="0">
+                <tree create="0" delete="0" edit="0" default_order="res_model,res_id">
                     <field name="id" />
-                    <field name="res_model" invisible="0"/>
-                    <field name="res_id" />
-                    <field name="value" />
+                    <field name="res_model" optional="hide" />
+                    <field name="res_id" optional="hide" />
+                    <button name="action_open_record" type="object" icon="fa-external-link-square" title="Open record" />
+                    <field name="value" optional="hide" />
+                    <field name="signed_value" />
                     <field name="factor_value_id" />
                     <field name="factor_value_type_id" widget="badge"/>
                     <field name="distribution" widget="percentage" />


### PR DESCRIPTION
This commit adds a signed_value field on carbon.line.origin to compute the signed value depending on the record type. The most typical example is account.move.line whose value should be negative for a out invoice.