### PR TITLE
FE - smart buttons - advanced

### DIFF
--- a/onsp_co2/models/carbon_factor.py
+++ b/onsp_co2/models/carbon_factor.py
@@ -491,7 +491,7 @@ class CarbonFactor(models.Model):
             },
         }
 
-    def _get_distribution_lines_ids(self, model: str) -> list[int]:
+    def _get_distribution_lines_res_ids(self, model: str) -> list[int]:
         distribution_lines = self.env["carbon.distribution.line"].search(
             [("res_model", "=", model), ("factor_id", "in", self.ids)]
         )
@@ -501,28 +501,28 @@ class CarbonFactor(models.Model):
         return self._generate_action(
             title=_("Child factors for"),
             model="carbon.factor",
-            ids=self._get_distribution_lines_ids("carbon.factor"),
+            ids=self._get_distribution_lines_res_ids("carbon.factor"),
         )
 
     def action_see_chart_of_account_ids(self):
         return self._generate_action(
             title=_("Chart of Account for"),
             model="account.account",
-            ids=self._get_distribution_lines_ids("account.account"),
+            ids=self._get_distribution_lines_res_ids("account.account"),
         )
 
     def action_see_product_ids(self):
         return self._generate_action(
             title=_("Product for"),
             model="product.template",
-            ids=self._get_distribution_lines_ids("product.template"),
+            ids=self._get_distribution_lines_res_ids("product.template"),
         )
 
     def action_see_product_categ_ids(self):
         return self._generate_action(
             title=_("Product Category for"),
             model="product.category",
-            ids=self._get_distribution_lines_ids("product.template"),
+            ids=self._get_distribution_lines_res_ids("product.template"),
         )
 
     def action_see_account_move_ids(self):

--- a/onsp_co2/models/carbon_factor.py
+++ b/onsp_co2/models/carbon_factor.py
@@ -69,7 +69,7 @@ class CarbonFactor(models.Model):
     chart_of_account_qty = fields.Integer(compute="_compute_chart_of_account_qty")
     product_qty = fields.Integer(compute="_compute_product_qty")
     product_categ_qty = fields.Integer(compute="_compute_product_categ_qty")
-    posted_entries_qty = fields.Integer(compute="_compute_posted_entries_qty")
+    account_move_qty = fields.Integer(compute="_compute_account_move_qty")
 
     # --------------------------------------------
 
@@ -107,7 +107,7 @@ class CarbonFactor(models.Model):
         for factor in self:
             factor.chart_of_account_qty = count_data.get(factor.id, 0)
 
-    def _compute_posted_entries_qty(self):
+    def _compute_account_move_qty(self):
         origins = self.env["carbon.line.origin"].read_group(
             [("factor_id", "in", self.ids)],
             ["factor_id"],
@@ -117,7 +117,7 @@ class CarbonFactor(models.Model):
             line["factor_id"][0]: line["factor_id_count"] for line in origins
         }
         for factor in self:
-            factor.posted_entries_qty = factor_id_to_count.get(factor.id, 0)
+            factor.account_move_qty = factor_id_to_count.get(factor.id, 0)
 
     def _compute_product_qty(self):
         count_data = self._get_count_by_model(model="product.template")
@@ -507,7 +507,7 @@ class CarbonFactor(models.Model):
             title=_("Product Category for"), model="product.category"
         )
 
-    def action_see_posted_entries(self):
+    def action_see_account_move_ids(self):
         origins = self.env["carbon.line.origin"].search([("factor_id", "in", self.ids)])
         return {
             "name": _("Journal Entries"),

--- a/onsp_co2/views/carbon_factor.xml
+++ b/onsp_co2/views/carbon_factor.xml
@@ -52,17 +52,17 @@
 
                   <button
                 type="object"
-                name="action_see_posted_entries"
+                name="action_see_account_move_ids"
                 class="oe_stat_button"
                 icon="fa-bars"
               >
                                 <div class="o_field_widget o_stat_info">
                                     <span
                     class="o_stat_value"
-                    attrs="{'invisible': [('posted_entries_qty', '&lt;=', 1)]}"
+                    attrs="{'invisible': [('account_move_qty', '&lt;=', 1)]}"
                   >
                                         <field
-                      name="posted_entries_qty"
+                      name="account_move_qty"
                       widget="statinfo"
                       nolabel="1"
                     />
@@ -70,10 +70,10 @@
                                     </span>
                                     <span
                     class="o_stat_value"
-                    attrs="{'invisible': [('posted_entries_qty', '&gt;', 1)]}"
+                    attrs="{'invisible': [('account_move_qty', '&gt;', 1)]}"
                   >
                                         <field
-                      name="posted_entries_qty"
+                      name="account_move_qty"
                       widget="statinfo"
                       nolabel="1"
                     />

--- a/onsp_co2/views/carbon_factor.xml
+++ b/onsp_co2/views/carbon_factor.xml
@@ -48,6 +48,42 @@
 
                     <sheet>
                         <div class="oe_button_box" name="button_box">
+
+
+                  <button
+                type="object"
+                name="action_see_posted_entries"
+                class="oe_stat_button"
+                icon="fa-bars"
+              >
+                                <div class="o_field_widget o_stat_info">
+                                    <span
+                    class="o_stat_value"
+                    attrs="{'invisible': [('posted_entries_qty', '&lt;=', 1)]}"
+                  >
+                                        <field
+                      name="posted_entries_qty"
+                      widget="statinfo"
+                      nolabel="1"
+                    />
+                                        Posted Entries
+                                    </span>
+                                    <span
+                    class="o_stat_value"
+                    attrs="{'invisible': [('posted_entries_qty', '&gt;', 1)]}"
+                  >
+                                        <field
+                      name="posted_entries_qty"
+                      widget="statinfo"
+                      nolabel="1"
+                    />
+                                        Posted Entry
+                                    </span>
+                                </div>
+                            </button>
+
+
+
                             <button
                 type="object"
                 name="action_see_child_ids"


### PR DESCRIPTION
Add a smart button that allows from the emission factor reference screen to visualize all associated accounting entries.

(The same functionality as what is done in the fixed assets screen to retrieve associated accounting entries.)