### PR TITLE
[FIX] Signed uncertainty digits & rename fields carbon_line_origin

### DIFF
--- a/onsp_co2/data/decimal_precision.xml
+++ b/onsp_co2/data/decimal_precision.xml
@@ -14,14 +14,5 @@
       <field name="name">Carbon Factor value</field>
       <field name="digits">6</field>
     </record>
-
-    <record
-      forcecreate="True"
-      id="decimal_signed_uncertainty"
-      model="decimal.precision"
-    >
-      <field name="name">Carbon Signed Uncertainty Value</field>
-      <field name="digits">2</field>
-    </record>
   </data>
 </odoo>

--- a/onsp_co2/models/carbon_line_origin.py
+++ b/onsp_co2/models/carbon_line_origin.py
@@ -25,15 +25,6 @@ class CarbonLineOrigin(models.Model):
         index=True, model_field="res_model", string="Res id"
     )
     factor_value_id = fields.Many2one("carbon.factor.value", string="Factor value")
-    move_id = fields.Many2one(
-        related="move_line_id.move_id", store=True, string="Journal Entry"
-    )
-    move_line_id = fields.Many2one(
-        "account.move.line",
-        compute="_compute_many2one_lines",
-        store=True,
-        string="Journal Item",
-    )
 
     value = fields.Float(
         digits="Carbon value", required=True, string="Factor Value"
@@ -61,7 +52,6 @@ class CarbonLineOrigin(models.Model):
         store=False,
         readonly=True,
     )
-
     comment = fields.Char()
 
     factor_id = fields.Many2one(
@@ -80,7 +70,16 @@ class CarbonLineOrigin(models.Model):
         store=True,
     )
 
-    # === account_move fields === #
+    # === account_move_line fields === #
+    move_line_id = fields.Many2one(
+        "account.move.line",
+        compute="_compute_many2one_lines",
+        store=True,
+        string="Journal Item",
+    )
+    move_id = fields.Many2one(
+        related="move_line_id.move_id", store=True, string="Journal Entry"
+    )
     move_company_currency_id = fields.Many2one(
         string="Company Currency",
         related="move_id.company_currency_id",
@@ -93,9 +92,7 @@ class CarbonLineOrigin(models.Model):
     move_state = fields.Selection(
         related="move_id.state", string="Status", readonly=True
     )
-
-    # === account_move_line fields === #
-    account_id = fields.Many2one(
+    move_line_account_id = fields.Many2one(
         related="move_line_id.account_id", store=True, string="Account"
     )
     move_line_partner_id = fields.Many2one(

--- a/onsp_co2/models/carbon_line_origin.py
+++ b/onsp_co2/models/carbon_line_origin.py
@@ -25,14 +25,14 @@ class CarbonLineOrigin(models.Model):
         index=True, model_field="res_model", string="Res id"
     )
     factor_value_id = fields.Many2one("carbon.factor.value", string="Factor value")
-    move_id = fields.Many2one(
-        related="move_line_id.move_id", store=True, string="Journal Entry"
-    )
     move_line_id = fields.Many2one(
         "account.move.line",
         compute="_compute_many2one_lines",
         store=True,
         string="Journal Item",
+    )
+    move_id = fields.Many2one(
+        related="move_line_id.move_id", store=True, string="Journal Entry"
     )
 
     value = fields.Float(
@@ -51,7 +51,7 @@ class CarbonLineOrigin(models.Model):
     signed_uncertainty_value = fields.Float(
         compute="_compute_signed_uncertainty_value",
         store=True,
-        digits="Carbon Signed Uncertainty Value",
+        digits="Carbon value",
     )
     compute_method = fields.Char()
     uom_id = fields.Many2one("uom.uom")
@@ -98,10 +98,10 @@ class CarbonLineOrigin(models.Model):
     account_id = fields.Many2one(
         related="move_line_id.account_id", store=True, string="Account"
     )
-    partner_id = fields.Many2one(
+    move_line_partner_id = fields.Many2one(
         related="move_line_id.partner_id", store=True, string="Partner"
     )
-    journal_id = fields.Many2one(
+    move_line_journal_id = fields.Many2one(
         related="move_line_id.journal_id", store=True, string="Journal"
     )
     move_line_balance = fields.Monetary(

--- a/onsp_co2/views/carbon_line_origin.xml
+++ b/onsp_co2/views/carbon_line_origin.xml
@@ -5,7 +5,14 @@
       <field name="name">carbon.line.origin.tree</field>
       <field name="model">carbon.line.origin</field>
       <field name="arch" type="xml">
-        <tree create="0" delete="0" edit="0" default_order="res_model,res_id">
+        <tree create="0" delete="0" edit="0">
+          <button
+            name="action_open_record"
+            type="object"
+            icon="fa-external-link-square"
+            title="Open record"
+            groups="base.group_no_one"
+          />
           <field name="move_date" string="Invoice Date" />
           <field name="move_line_journal_id" optional="hide" string="Journal" />
           <field name="move_id" widget="many2one" string="Journal Entry" />

--- a/onsp_co2/views/carbon_line_origin.xml
+++ b/onsp_co2/views/carbon_line_origin.xml
@@ -7,10 +7,10 @@
       <field name="arch" type="xml">
         <tree create="0" delete="0" edit="0" default_order="res_model,res_id">
           <field name="move_date" string="Invoice Date" />
-          <field name="journal_id" optional="hide" string="Journal" />
+          <field name="move_line_journal_id" optional="hide" string="Journal" />
           <field name="move_id" widget="many2one" string="Journal Entry" />
           <field name="account_id" optional="hide" string="Account" />
-          <field name="partner_id" string="Partner" />
+          <field name="move_line_partner_id" string="Partner" />
           <field name="move_line_label" string="Label" />
           <field name="move_line_quantity" string="Quantity" />
           <field name="move_line_product_uom_id" string="Unit of Measure" />
@@ -22,7 +22,11 @@
           />
           <field name="move_line_balance" string="Amount" />
           <field name="signed_value" string="Total (KgCO2e)" />
-          <field name="signed_uncertainty_value" string="Uncertainty (KgCO2e)" />
+          <field
+            name="signed_uncertainty_value"
+            string="Uncertainty (KgCO2e)"
+            digits="[13,2]"
+          />
           <field name="factor_id" widget="many2one" string="Emission Factor" />
           <field
             name="uncertainty_percentage"
@@ -56,12 +60,12 @@
     </record>
 
     <record id="carbon_line_origin_filter" model="ir.ui.view">
-      <field name="name">carbon.line.origin.select</field>
+      <field name="name">carbon.line.origin.filter</field>
       <field name="model">carbon.line.origin</field>
       <field name="arch" type="xml">
         <search string="Search Emission Factor">
           <field name="move_id" string="Journal Entry" />
-          <field name="partner_id" string="Partner" />
+          <field name="move_line_partner_id" string="Partner" />
           <field name="move_line_label" string="Label" />
           <field name="factor_id" string="Name" />
           <field name="factor_value_type_id" string="Type" />
@@ -83,13 +87,13 @@
           <separator />
           <filter
             string="Posted"
-            name="posted"
-            domain="[('move_state', '=', 'posted')]"
+            name="posted_invoice_lines"
+            domain="[('move_state', '=', 'posted'), ('res_model', '=', 'account.move.line')]"
           />
           <filter
             string="Unposted"
             name="unposted"
-            domain="[('move_state', '!=', 'posted')]"
+            domain="[('move_state', '!=', 'posted'), ('res_model', '=', 'account.move.line')]"
           />
           <filter string="Invoice Date" name="date" date="move_date" />
           <group expand="0" string="Group By">
@@ -126,8 +130,8 @@
             <separator />
             <filter
               string="Partner"
-              name="by_partner_id"
-              context="{'group_by': 'partner_id'}"
+              name="by_move_line_partner_id"
+              context="{'group_by': 'move_line_partner_id'}"
             />
             <filter
               string="Invoice Date"

--- a/onsp_co2/views/carbon_line_origin.xml
+++ b/onsp_co2/views/carbon_line_origin.xml
@@ -16,7 +16,7 @@
           <field name="move_date" string="Invoice Date" />
           <field name="move_line_journal_id" optional="hide" string="Journal" />
           <field name="move_id" widget="many2one" string="Journal Entry" />
-          <field name="account_id" optional="hide" string="Account" />
+          <field name="move_line_account_id" optional="hide" string="Account" />
           <field name="move_line_partner_id" string="Partner" />
           <field name="move_line_label" string="Label" />
           <field name="move_line_quantity" string="Quantity" />

--- a/onsp_co2/views/carbon_line_origin.xml
+++ b/onsp_co2/views/carbon_line_origin.xml
@@ -60,7 +60,7 @@
     </record>
 
     <record id="carbon_line_origin_filter" model="ir.ui.view">
-      <field name="name">carbon.line.origin.filter</field>
+      <field name="name">carbon.line.origin.select</field>
       <field name="model">carbon.line.origin</field>
       <field name="arch" type="xml">
         <search string="Search Emission Factor">

--- a/onsp_co2/views/carbon_line_origin.xml
+++ b/onsp_co2/views/carbon_line_origin.xml
@@ -87,7 +87,7 @@
           <separator />
           <filter
             string="Posted"
-            name="posted_invoice_lines"
+            name="posted"
             domain="[('move_state', '=', 'posted'), ('res_model', '=', 'account.move.line')]"
           />
           <filter


### PR DESCRIPTION
## Description

- Move digits cut to xml and restore previous digits in signed uncertainty fields
- Rename fileds in carbon line origin model
- Restore debug method

Review (with answered comments) is here: https://github.com/MyCityCO2/mycityco2-engine/commit/38ce7876a22476b15b735abf83d2539068c16986