### PR TITLE
[IMP] Add warning when no res_model and add recompute server action on carbon origin line (debug mode only)

### DIFF
--- a/onsp_co2/data/decimal_precision.xml
+++ b/onsp_co2/data/decimal_precision.xml
@@ -14,5 +14,14 @@
       <field name="name">Carbon Factor value</field>
       <field name="digits">6</field>
     </record>
+
+    <record
+      forcecreate="True"
+      id="decimal_signed_uncertainty"
+      model="decimal.precision"
+    >
+      <field name="name">Carbon Signed Uncertainty Value</field>
+      <field name="digits">2</field>
+    </record>
   </data>
 </odoo>

--- a/onsp_co2/models/carbon_line_origin.py
+++ b/onsp_co2/models/carbon_line_origin.py
@@ -1,6 +1,7 @@
 import logging
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 _logger = logging.getLogger(__name__)
 
@@ -176,6 +177,12 @@ class CarbonLineOrigin(models.Model):
     def get_record(self):
         """Return the record that generated this origin"""
         self.ensure_one()
+        if not self.res_model:
+            raise ValidationError(
+                _(
+                    "You're carbon line origin doesn't have a reference model, this shouldn't be possible..."
+                )
+            )
         if self.res_model in self.env and (
             fname := self._get_model_to_field_name().get(self.res_model)
         ):

--- a/onsp_co2/models/carbon_line_origin.py
+++ b/onsp_co2/models/carbon_line_origin.py
@@ -1,6 +1,6 @@
 import logging
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -24,33 +24,112 @@ class CarbonLineOrigin(models.Model):
     res_id = fields.Many2oneReference(
         index=True, model_field="res_model", string="Res id"
     )
-
     factor_value_id = fields.Many2one("carbon.factor.value", string="Factor value")
-    factor_value_type_id = fields.Many2one(
-        related="factor_value_id.type_id", string="Factor Value Type"
+    move_id = fields.Many2one(
+        related="move_line_id.move_id", store=True, string="Journal Entry"
     )
-    factor_id = fields.Many2one(
-        related="factor_value_id.factor_id", string="Carbon Factor", store=True
+    move_line_id = fields.Many2one(
+        "account.move.line",
+        compute="_compute_many2one_lines",
+        store=True,
+        string="Journal Item",
     )
 
     value = fields.Float(
-        digits="Carbon value", required=True
+        digits="Carbon value", required=True, string="Factor Value"
     )  # Result of the computation (might be a partial result)
     signed_value = fields.Float(
-        compute="_compute_signed_value", store=True, digits="Carbon value"
+        compute="_compute_signed_value",
+        store=True,
+        digits="Carbon value",
+        string="Total",
     )
     distribution = fields.Float()
-    carbon_value = fields.Float(digits="Carbon Factor value")
-    uncertainty_percentage = fields.Float(default=0.0)
+    carbon_value = fields.Float(digits="Carbon Factor value", string="Value")
+    uncertainty_percentage = fields.Float(default=0.0, string="Uncertainty")
     uncertainty_value = fields.Float(default=0.0, digits="Carbon Factor value")
     signed_uncertainty_value = fields.Float(
-        compute="_compute_signed_uncertainty_value", store=True, digits="Carbon value"
+        compute="_compute_signed_uncertainty_value",
+        store=True,
+        digits="Carbon Signed Uncertainty Value",
     )
     compute_method = fields.Char()
     uom_id = fields.Many2one("uom.uom")
-    monetary_currency_id = fields.Many2one("res.currency")
+    monetary_currency_id = fields.Many2one("res.currency", string="Currency")
+    carbon_data_uncertainty_percentage = fields.Float(
+        related="move_line_id.carbon_data_uncertainty_percentage",
+        store=False,
+        readonly=True,
+    )
 
     comment = fields.Char()
+
+    factor_id = fields.Many2one(
+        related="factor_value_id.factor_id", string="Name", store=True
+    )
+    factor_value_type_id = fields.Many2one(
+        related="factor_value_id.type_id", string="Factor Value Type", store=True
+    )
+
+    factor_category_id = fields.Many2one(
+        related="factor_id.parent_id", string="Factor Category", store=True
+    )
+    factor_source_id = fields.Many2one(
+        related="factor_id.carbon_source_id",
+        string="Factor Source",
+        store=True,
+    )
+
+    # === account_move fields === #
+    move_company_currency_id = fields.Many2one(
+        string="Company Currency",
+        related="move_id.company_currency_id",
+        readonly=True,
+        store=False,
+    )
+    move_date = fields.Date(
+        related="move_id.date", string="Invoice Date", readonly=True, store=True
+    )
+    move_state = fields.Selection(
+        related="move_id.state", string="Status", readonly=True
+    )
+
+    # === account_move_line fields === #
+    account_id = fields.Many2one(
+        related="move_line_id.account_id", store=True, string="Account"
+    )
+    partner_id = fields.Many2one(
+        related="move_line_id.partner_id", store=True, string="Partner"
+    )
+    journal_id = fields.Many2one(
+        related="move_line_id.journal_id", store=True, string="Journal"
+    )
+    move_line_balance = fields.Monetary(
+        related="move_line_id.balance",
+        string="Balance",
+        readonly=True,
+        store=False,
+        currency_field="move_company_currency_id",
+    )
+    move_line_label = fields.Char(
+        related="move_line_id.name",
+        string="Label",
+        compute="_compute_name",
+        store=False,
+        readonly=True,
+    )
+    move_line_quantity = fields.Float(
+        related="move_line_id.quantity",
+        string="Quantity",
+        store=False,
+        readonly=True,
+    )
+    move_line_product_uom_id = fields.Many2one(
+        related="move_line_id.product_uom_id",
+        string="Unit of Measure",
+        store=False,
+        readonly=True,
+    )
 
     @api.model
     def _get_model_to_field_name(self) -> dict[str, str]:
@@ -67,16 +146,6 @@ class CarbonLineOrigin(models.Model):
 
     These are useful to create related fields!
     """
-    move_line_id = fields.Many2one(
-        "account.move.line",
-        compute="_compute_many2one_lines",
-        store=True,
-        string="Move Line",
-    )
-    move_id = fields.Many2one(related="move_line_id.move_id", store=True, string="Move")
-    account_id = fields.Many2one(
-        related="move_line_id.account_id", store=True, string="Account"
-    )
 
     @api.depends("res_model", "res_id")
     def _compute_many2one_lines(self):
@@ -132,27 +201,3 @@ class CarbonLineOrigin(models.Model):
         res = super().create(vals_list)
         self._clean_orphan_lines()
         return res
-
-    # --------------------------------------------
-    #                   ACTIONS
-    # --------------------------------------------
-
-    def action_open_record(self):
-        self.ensure_one()
-        if record := self.get_record():
-            action = record.get_formview_action()
-            action["target"] = "new"
-            return action
-        return {
-            "type": "ir.actions.client",
-            "tag": "display_notification",
-            "params": {
-                "title": _("Error"),
-                "message": _(
-                    "Couldn't open record: %s,%s", self.res_model, self.res_id
-                ),
-                "type": "danger",
-                "sticky": False,
-                "next": {"type": "ir.actions.act_window_close"},
-            },
-        }

--- a/onsp_co2/views/carbon_line_origin.xml
+++ b/onsp_co2/views/carbon_line_origin.xml
@@ -6,32 +6,136 @@
       <field name="model">carbon.line.origin</field>
       <field name="arch" type="xml">
         <tree create="0" delete="0" edit="0" default_order="res_model,res_id">
-          <field name="id" />
-          <field name="res_model" optional="hide" />
-          <field name="res_id" optional="hide" />
-          <button
-            name="action_open_record"
-            type="object"
-            icon="fa-external-link-square"
-            title="Open record"
+          <field name="move_date" string="Invoice Date" />
+          <field name="journal_id" optional="hide" string="Journal" />
+          <field name="move_id" widget="many2one" string="Journal Entry" />
+          <field name="account_id" optional="hide" string="Account" />
+          <field name="partner_id" string="Partner" />
+          <field name="move_line_label" string="Label" />
+          <field name="move_line_quantity" string="Quantity" />
+          <field name="move_line_product_uom_id" string="Unit of Measure" />
+          <field
+            name="carbon_data_uncertainty_percentage"
+            widget="percentage"
+            optional="hide"
+            string="Data CO2 Uncertainty"
           />
-          <field name="value" optional="hide" />
-          <field name="signed_value" />
-          <field name="factor_value_id" />
-          <field name="factor_value_type_id" widget="badge" />
-          <field name="distribution" widget="percentage" />
-          <field name="compute_method" />
-          <field name="carbon_value" />
-          <field name="monetary_currency_id" />
-          <field name="uncertainty_percentage" widget="percentage" />
-          <field name="uncertainty_value" optional="hide" />
-          <field name="signed_uncertainty_value" />
-          <field name="comment" />
+          <field name="move_line_balance" string="Amount" />
+          <field name="signed_value" string="Total (KgCO2e)" />
+          <field name="signed_uncertainty_value" string="Uncertainty (KgCO2e)" />
+          <field name="factor_id" widget="many2one" string="Emission Factor" />
+          <field
+            name="uncertainty_percentage"
+            widget="percentage"
+            optional="hide"
+            string="Uncertainty"
+          />
+          <field name="compute_method" optional="hide" string="Compute Method" />
+          <field name="carbon_value" optional="hide" string="Value" />
+          <field
+            name="distribution"
+            widget="percentage"
+            optional="hide"
+            string="Distribution"
+          />
+          <field name="factor_value_type_id" widget="badge" string="Type" />
+          <field name="factor_category_id" widget="badge" string="Category" />
+          <field name="factor_source_id" optional="hide" string="Source" />
+          <field name="create_date" optional="hide" widget="date" string="Created On" />
+          <field
+            name="move_state"
+            widget="badge"
+            decoration-info="move_state == 'draft'"
+            decoration-success="move_state == 'posted'"
+            string="Status"
+          />
 
-          <field name="move_line_id" optional="hide" />
-          <field name="move_id" optional="hide" />
-          <field name="account_id" optional="hide" />
+          <field name="move_company_currency_id" invisible="1" />
         </tree>
+      </field>
+    </record>
+
+    <record id="carbon_line_origin_filter" model="ir.ui.view">
+      <field name="name">carbon.line.origin.select</field>
+      <field name="model">carbon.line.origin</field>
+      <field name="arch" type="xml">
+        <search string="Search Emission Factor">
+          <field name="move_id" string="Journal Entry" />
+          <field name="partner_id" string="Partner" />
+          <field name="move_line_label" string="Label" />
+          <field name="factor_id" string="Name" />
+          <field name="factor_value_type_id" string="Type" />
+          <field name="factor_category_id" string="Category" />
+          <field name="move_line_product_uom_id" string='Unit of Measure' />
+          <field name="move_state" string="Status" />
+
+          <filter
+            string="Physical"
+            name="physical"
+            domain="[('compute_method', '=', 'physical')]"
+          />
+          <filter
+            string="Monetary"
+            name="monetary"
+            domain="[('compute_method', '=', 'monetary')]"
+          />
+          <filter string="Creation Date" name="date" date="create_date" />
+          <separator />
+          <filter
+            string="Posted"
+            name="posted"
+            domain="[('move_state', '=', 'posted')]"
+          />
+          <filter
+            string="Unposted"
+            name="unposted"
+            domain="[('move_state', '!=', 'posted')]"
+          />
+          <filter string="Invoice Date" name="date" date="move_date" />
+          <group expand="0" string="Group By">
+            <filter
+              string="Emission Factor"
+              name="by_factor_id"
+              context="{'group_by':'factor_id'}"
+            />
+            <filter
+              string="Category"
+              name="by_factor_category_id"
+              context="{'group_by':'factor_category_id'}"
+            />
+            <filter
+              string="Type"
+              name="by_factor_value_type_id"
+              context="{'group_by':'factor_value_type_id'}"
+            />
+            <filter
+              string="Source"
+              name="by_carbon_source_id"
+              context="{'group_by':'factor_source_id'}"
+            />
+            <filter
+              string="Compute Method"
+              name="by_compute_method"
+              context="{'group_by':'compute_method'}"
+            />
+            <filter
+              string="Creation Date"
+              name="by_create_date"
+              context="{'group_by': 'create_date'}"
+            />
+            <separator />
+            <filter
+              string="Partner"
+              name="by_partner_id"
+              context="{'group_by': 'partner_id'}"
+            />
+            <filter
+              string="Invoice Date"
+              name="by_move_date"
+              context="{'group_by': 'move_date'}"
+            />
+          </group>
+        </search>
       </field>
     </record>
 
@@ -40,6 +144,7 @@
       <field name="res_model">carbon.line.origin</field>
       <field name="type">ir.actions.act_window</field>
       <field name="view_mode">tree</field>
+      <field name="context">{'search_default_posted': 1}</field>
     </record>
   </data>
 </odoo>

--- a/onsp_co2/views/carbon_line_origin.xml
+++ b/onsp_co2/views/carbon_line_origin.xml
@@ -147,4 +147,13 @@
       <field name="context">{'search_default_posted': 1}</field>
     </record>
   </data>
+
+  <record id="action_recompute_carbon_line_origin" model="ir.actions.server">
+    <field name="name">Re-compute CO2</field>
+    <field name="model_id" ref="model_carbon_line_origin" />
+    <field name="binding_model_id" ref="model_carbon_line_origin" />
+    <field name="state">code</field>
+    <field name="code">action = records.action_recompute_carbon()</field>
+    <field name="groups_id" eval="[Command.set([ref('base.group_no_one')])]" />
+  </record>
 </odoo>


### PR DESCRIPTION
## Description

This PR add error handling if res_model is not defined. Also added Recompute co2 on carbon line origin in debug mode

## Related Issues

An error occurred in one of our bases so it can happen, so if it can happen then need error handling 😂

## Self proofreading checklist

- [x] **Code Review**: Have you reviewed your code to ensure it follows best practices
      and meets the project's coding standards?
- [x] **Testing**: Have you tested your changes locally to ensure they work as expected?
- [x] **Documentation**: Have you updated any relevant documentation or comments to
      reflect your changes?
- [x] **Pre-commit Checks**: Have you ensured that pre-commit checks have automatically
      run upon committing to catch any potential issues?

## Test Instructions

Accounting -> Settings -> Carbon Origin -> Action -> Re-Compute Co2
Only in debug mode

An error should be raise if res_model not defined