### PR TITLE
[IMP] onsp_co2_employee_commuting: add carbon orgin support

### DIFF
--- a/onsp_co2_employee_commuting/models/carbon_hr_commuting.py
+++ b/onsp_co2_employee_commuting/models/carbon_hr_commuting.py
@@ -5,6 +5,7 @@ from .hr_employee import WEEKS_PER_MONTH
 
 class CarbonCommuting(models.Model):
     _name = "carbon.hr.commuting"
+    _description = "Carbon Employee Commuting"
 
     carbon_factor_id = fields.Many2one(
         "carbon.factor",
@@ -27,7 +28,7 @@ class CarbonCommuting(models.Model):
         (
             commuting_value,
             commmuting_uncertainty_value,
-            infos,
+            details,
         ) = self.carbon_factor_id.get_carbon_value(
             date=date,
             carbon_type="in",
@@ -35,4 +36,4 @@ class CarbonCommuting(models.Model):
             from_uom_id=self.env.ref("uom.product_uom_km"),
             data_uncertainty_percentage=0,
         )
-        return commuting_value, commmuting_uncertainty_value
+        return commuting_value, commmuting_uncertainty_value, details

--- a/onsp_co2_employee_commuting/models/res_company.py
+++ b/onsp_co2_employee_commuting/models/res_company.py
@@ -146,6 +146,13 @@ class ResCompany(models.Model):
                     {
                         "carbon_debt": commuting_carbon,
                         "name": f"{employee.name}{commuting_details}",
+                        "carbon_origin_json": {
+                            "mode": "manual",
+                            "details": {
+                                "uid": self.env.uid,
+                                "username": self.env.user.name,
+                            },
+                        },
                     }
                 )
                 aml_vals_list.append((0, 0, aml_vals))


### PR DESCRIPTION
## Description

Add carbon origin info when generating hr employee commuting account move.

## Self proofreading checklist

- [x] **Code Review**: Have you reviewed your code to ensure it follows best practices
      and meets the project's coding standards?
- [x] **Testing**: Have you tested your changes locally to ensure they work as expected?
- [x] **Documentation**: Have you updated any relevant documentation or comments to
      reflect your changes?
- [x] **Pre-commit Checks**: Have you ensured that pre-commit checks have automatically
      run upon committing to catch any potential issues?

## Test Instructions

Generate move with the scheduled action "Create account_moves of carbon emissions due to employee commuting" 
Created invoice lines should have related carbon line origin

## Additional Notes

This could benefit from an improvement of carbon line origin Comment system
