### PR TITLE
[FIX] remove open record

### DIFF
--- a/sustainability/models/carbon_line_origin.py
+++ b/sustainability/models/carbon_line_origin.py
@@ -1,6 +1,6 @@
 import logging
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 _logger = logging.getLogger(__name__)
 
@@ -203,27 +203,3 @@ class CarbonLineOrigin(models.Model):
         res = super().create(vals_list)
         self._clean_orphan_lines()
         return res
-
-    # --------------------------------------------
-    #                   ACTIONS
-    # --------------------------------------------
-
-    def action_open_record(self):
-        self.ensure_one()
-        if record := self.get_record():
-            action = record.get_formview_action()
-            action["target"] = "new"
-            return action
-        return {
-            "type": "ir.actions.client",
-            "tag": "display_notification",
-            "params": {
-                "title": _("Error"),
-                "message": _(
-                    "Couldn't open record: %s,%s", self.res_model, self.res_id
-                ),
-                "type": "danger",
-                "sticky": False,
-                "next": {"type": "ir.actions.act_window_close"},
-            },
-        }

--- a/sustainability/views/carbon_line_origin.xml
+++ b/sustainability/views/carbon_line_origin.xml
@@ -6,7 +6,6 @@
             <field name="model">carbon.line.origin</field>
             <field name="arch" type="xml">
                 <tree create="0" delete="0" edit="0">
-                    <button name="action_open_record" type="object" icon="fa-external-link-square" title="Open record" groups="base.group_no_one" />
                     <field name="move_date" string="Invoice Date" />
                     <field name="move_line_journal_id" optional="hide" string="Journal" />
                     <field name="move_id" widget="many2one" string="Journal Entry" />


### PR DESCRIPTION
## Description

The Open Record button on carbon line origin should be shown only in debug mode, but it is shown even if debug mode is false, it needs a re-trigger of the debug mode in order to be hidden. 

It is not a useful feature for the end user saw that the carbon line origin now have enough information and what is shown in the modal of Open Record is redundant.

This PR is removing the method and the button, if needed in the future we will still have it available in the history.

