### PR TITLE
[FIX] sustainability_employee_commmuting: demo data - generate entry for each month

### DIFF
--- a/sustainability/demo/demo.xml
+++ b/sustainability/demo/demo.xml
@@ -113,7 +113,7 @@
         <!-- For commuting demo data -->
         <record id="account_journal_carbon" model="account.journal">
             <field name="name">Carbon</field>
-            <field name="type">general</field>
+            <field name="type">purchase</field>
             <field name="code">CO2</field>
             <field name="currency_id" ref="base.USD" />
         </record>

--- a/sustainability_employee_commuting/data/demo.xml
+++ b/sustainability_employee_commuting/data/demo.xml
@@ -13,11 +13,6 @@
             <field name="distance_km">50</field>
             <field name="employee_id" ref="hr.employee_admin" />
         </record>
-        <record id="demo_carbon_commuting_fme" model="carbon.hr.commuting">
-            <field name="carbon_factor_id" ref="sustainability.carbon_factor_electric_bicycle" />
-            <field name="distance_km">45</field>
-            <field name="employee_id" ref="hr.employee_fme" />
-        </record>
         <record id="demo_carbon_commuting_mit" model="carbon.hr.commuting">
             <field name="carbon_factor_id" ref="sustainability.carbon_factor_bicycle" />
             <field name="distance_km">40</field>
@@ -33,10 +28,10 @@
             <field name="distance_km">55</field>
             <field name="employee_id" ref="hr.employee_stw" />
         </record>
-        <record id="demo_carbon_commuting_han" model="carbon.hr.commuting">
+        <record id="demo_carbon_commuting_fme" model="carbon.hr.commuting">
             <field name="carbon_factor_id" ref="sustainability.carbon_factor_walking" />
             <field name="distance_km">25</field>
-            <field name="employee_id" ref="hr.employee_han" />
+            <field name="employee_id" ref="hr.employee_fme" />
         </record>
 
         <function model="res.company" name="_cron_carbon_commuting_account_move_create">

--- a/sustainability_employee_commuting/data/demo.xml
+++ b/sustainability_employee_commuting/data/demo.xml
@@ -13,6 +13,16 @@
             <field name="distance_km">50</field>
             <field name="employee_id" ref="hr.employee_admin" />
         </record>
+        <record id="demo_carbon_commuting_fme" model="carbon.hr.commuting">
+            <field name="carbon_factor_id" ref="sustainability.carbon_factor_electric_bicycle" />
+            <field name="distance_km">45</field>
+            <field name="employee_id" ref="hr.employee_fme" />
+        </record>
+        <record id="demo_carbon_commuting_mit" model="carbon.hr.commuting">
+            <field name="carbon_factor_id" ref="sustainability.carbon_factor_bicycle" />
+            <field name="distance_km">40</field>
+            <field name="employee_id" ref="hr.employee_mit" />
+        </record>
         <record id="demo_carbon_commuting_al" model="carbon.hr.commuting">
             <field name="carbon_factor_id" ref="sustainability.carbon_factor_bus" />
             <field name="distance_km">60</field>
@@ -21,7 +31,12 @@
         <record id="demo_carbon_commuting_stw" model="carbon.hr.commuting">
             <field name="carbon_factor_id" ref="sustainability.carbon_factor_metro" />
             <field name="distance_km">55</field>
-            <field name="employee_id" ref="hr.employee_fme" />
+            <field name="employee_id" ref="hr.employee_stw" />
+        </record>
+        <record id="demo_carbon_commuting_han" model="carbon.hr.commuting">
+            <field name="carbon_factor_id" ref="sustainability.carbon_factor_walking" />
+            <field name="distance_km">25</field>
+            <field name="employee_id" ref="hr.employee_han" />
         </record>
 
         <function model="res.company" name="_cron_carbon_commuting_account_move_create">

--- a/sustainability_employee_commuting/models/res_company.py
+++ b/sustainability_employee_commuting/models/res_company.py
@@ -183,7 +183,7 @@ class ResCompany(models.Model):
             notification_message = (
                 f"Error processing employee {employee.name}: {str(e)}."
             )
-            _logger.info(notification_message)
+            _logger.error(notification_message)
             employee.message_post(
                 body=notification_message,
                 subject=f"Error Notification : Commuting Carbon print on the {account_move_date.strftime('%Y-%m-%d')}",


### PR DESCRIPTION
## Description

Fix: if CO2 commuting calculation is activated e.g. in October, only January's activities data are generated