### PR TITLE
[IMP] sustainability: change license to LGPL-3

### DIFF
--- a/sustainability/README.rst
+++ b/sustainability/README.rst
@@ -13,9 +13,9 @@ Sustainability
 .. |badge1| image:: https://img.shields.io/badge/maturity-Production%2FStable-green.png
     :target: https://odoo-community.org/page/development-status
     :alt: Production/Stable
-.. |badge2| image:: https://img.shields.io/badge/licence-AGPL--3-blue.png
-    :target: http://www.gnu.org/licenses/agpl-3.0-standalone.html
-    :alt: License: AGPL-3
+.. |badge2| image:: https://img.shields.io/badge/licence-LGPL--3-blue.png
+    :target: http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+    :alt: License: LGPL-3
 .. |badge3| image:: https://img.shields.io/badge/github-sustainability--suite%2Fsustainability--odoo-lightgray.png?logo=github
     :target: https://github.com/sustainability-suite/sustainability-odoo/tree/17.0/sustainability
     :alt: sustainability-suite/sustainability-odoo

--- a/sustainability/__manifest__.py
+++ b/sustainability/__manifest__.py
@@ -1,5 +1,5 @@
-# © 2021 Open Net Sarl
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+# © 2024 Open Net Sarl
+# License LGPL-3 or later (https://www.gnu.org/licenses/agpl).
 
 {
     "name": "Sustainability",
@@ -60,6 +60,6 @@
     "installable": True,
     "application": True,
     "auto_install": False,
-    "license": "AGPL-3",
+    "license": "LGPL-3",
     "sequence": 1,
 }


### PR DESCRIPTION
Current situation :
sutainability module is AGPL-3 which means that all modules depending on it are required to be AGPL-3.
This is an issue if we want to have a module depending both on sustainability and an EE module (OEEL-1).

Proposition : change licence of sustainability module to LGPL-3

https://apps.odoo.com/apps/faq#maintainer_faq_04