### PR TITLE
WIP: Run CI tests via GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,21 @@
       test:
         runs-on: ubuntu-22.04
         container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
-        name: test with Odoo
+        name: Test module ${{ matrix.INCLUDE }}
         strategy:
           fail-fast: false
+          matrix:
+             INCLUDE:
+               - sustainability
+               - sustainability_account_accountant
+               - sustainability_account_asset
+               - sustainability_account_asset_management
+               - sustainability_employee_commuting
+               - sustainability_hr_expense_report
+               - sustainability_mis_builder
+               - sustainability_purchase
+        env:
+          INCLUDE: ${{ matrix.INCLUDE }}
         services:
           postgres:
             image: postgres:16.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,3 +36,32 @@
                   echo "$newfiles"
                   exit 1
               fi
+      test:
+        runs-on: ubuntu-22.04
+        container: ghcr.io/oca/oca-ci/py3.10-odoo17.0:latest
+        name: test with Odoo
+        strategy:
+          fail-fast: false
+        services:
+          postgres:
+            image: postgres:16.0
+            env:
+              POSTGRES_USER: odoo
+              POSTGRES_PASSWORD: odoo
+              POSTGRES_DB: odoo
+            ports:
+              - 5432:5432
+        steps:
+          - uses: actions/checkout@v3
+            with:
+              persist-credentials: false
+          - name: Install addons and dependencies
+            run: oca_install_addons
+          - name: Check licenses
+            run: manifestoo -d . check-licenses
+          - name: Check development status
+            run: manifestoo -d . check-dev-status --default-dev-status=Beta
+          - name: Initialize test db
+            run: oca_init_test_database
+          - name: Run tests
+            run: oca_run_tests

--- a/sustainability_account_accountant/__manifest__.py
+++ b/sustainability_account_accountant/__manifest__.py
@@ -10,7 +10,7 @@
     "maintainers": ["jguenat", "bonnetadam", "jacopobacci"],
     "development_status": "Production/Stable",
     "website": "https://www.open-net.ch",
-    "depends": ["sustainability", "account_accountant"],
+    "depends": ["sustainability"],
     "assets": {
         "web.assets_backend": [],
     },

--- a/sustainability_account_asset/__manifest__.py
+++ b/sustainability_account_asset/__manifest__.py
@@ -7,7 +7,7 @@
     "development_status": "Production/Stable",
     "category": "Accounting/Sustainability",
     "website": "https://www.open-net.ch",
-    "depends": ["account_asset", "sustainability"],
+    "depends": ["sustainability"],
     "data": [
         "views/account_asset.xml",
     ],

--- a/sustainability_mis_builder/__manifest__.py
+++ b/sustainability_mis_builder/__manifest__.py
@@ -10,7 +10,7 @@
     "development_status": "Production/Stable",
     "category": "Accounting/Sustainability",
     "website": "https://www.open-net.ch",
-    "depends": ["mis_builder", "sustainability"],
+    "depends": ["sustainability"],
     "data": [
         "views/mis_carbon_account_move_line.xml",
         "security/ir.model.access.csv",


### PR DESCRIPTION
## Description

Run tests per module via Github actions

## Related Issues

Related to #193 ; the tests could ideally be ran via Github actions, this is a very initial draft.

## Additional Notes

This is very heavily ~inspired~ copy-pasted from OCA's recipes: https://github.com/OCA/oca-ci, and should not be merged as-is (the tests don't even start for some modules)
