### PR TITLE
[17.0][FIX]Remove import of `tests` folder

### DIFF
--- a/sustainability/__init__.py
+++ b/sustainability/__init__.py
@@ -2,4 +2,3 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from . import models
-from . import tests


### PR DESCRIPTION
tests folder doesn't need to be imported to make the unit tests discovered.

It makes a useless name binding as this code doesn't need to be available from the module code.