### PR TITLE
[FIX] sustainability: tests preceeding order

### DIFF
--- a/sustainability/tests/test_preceeding_order.py
+++ b/sustainability/tests/test_preceeding_order.py
@@ -13,6 +13,7 @@ class TestPreceedingOrder(CarbonCommon):
                 "list_price": 50.00,
                 "standard_price": 40.00,
                 "uom_id": cls.uom_hour.id,
+                "uom_po_id": cls.uom_hour.id,  # Ensures UoM categories match
                 "carbon_in_factor_id": cls.carbon_factor_physical.id,
                 "carbon_in_is_manual": True,
             }
@@ -126,6 +127,7 @@ class TestPreceedingOrder(CarbonCommon):
                 "list_price": 50.00,
                 "standard_price": 40.00,
                 "uom_id": self.uom_hour.id,
+                "uom_po_id": self.uom_hour.id,
                 "categ_id": product_category.id,
             }
         )
@@ -184,6 +186,8 @@ class TestPreceedingOrder(CarbonCommon):
                 "name": "Test Product Template",
                 "carbon_in_is_manual": True,
                 "carbon_in_factor_id": self.carbon_factor_physical.id,
+                "uom_id": self.uom_hour.id,
+                "uom_po_id": self.uom_hour.id,
                 "attribute_line_ids": [
                     Command.create(
                         {
@@ -206,6 +210,7 @@ class TestPreceedingOrder(CarbonCommon):
                 "list_price": 50.00,
                 "standard_price": 40.00,
                 "uom_id": self.uom_hour.id,
+                "uom_po_id": self.uom_hour.id,
                 "product_tmpl_id": product_template.id,
             }
         )
@@ -265,6 +270,7 @@ class TestPreceedingOrder(CarbonCommon):
                 "list_price": 50.00,
                 "standard_price": 40.00,
                 "uom_id": self.uom_hour.id,
+                "uom_po_id": self.uom_hour.id,
             }
         )
 
@@ -312,6 +318,7 @@ class TestPreceedingOrder(CarbonCommon):
                 "list_price": 50.00,
                 "standard_price": 40.00,
                 "uom_id": self.uom_hour.id,
+                "uom_po_id": self.uom_hour.id,
             }
         )
 


### PR DESCRIPTION
add uom_po_id to ensure unit of measure consistency in tests