### PR TITLE
[PERF] sustainability*: improve performance

### DIFF
--- a/sustainability/models/account_move_line.py
+++ b/sustainability/models/account_move_line.py
@@ -119,23 +119,13 @@ class AccountMoveLine(models.Model):
     # --------------------------------------------
 
     @api.depends(
-        # Seller
-        "product_id.seller_ids",
-        "product_id.seller_ids.carbon_in_factor_id",
-        "move_id.partner_id",
-        # Partner
+        "product_id",
         "partner_id",
-        "partner_id.carbon_in_factor_id",
-        # Other
-        "account_id.carbon_in_factor_id",
-        "product_id.carbon_in_factor_id",
-        "product_id.carbon_out_factor_id",
         "quantity",
         "credit",
         "debit",
         "move_type",
-        "move_id.invoice_date",
-        "move_id.company_id.carbon_lock_date",
+        "invoice_date",
         "carbon_data_uncertainty_percentage",
     )
     def _compute_carbon_debt(self, force_compute: bool | str | list[str] = None):

--- a/sustainability/models/carbon_line_mixin.py
+++ b/sustainability/models/carbon_line_mixin.py
@@ -154,7 +154,7 @@ class CarbonLineMixin(models.AbstractModel):
     def _get_lines_to_compute_domain(self, force_compute: list[str]):
         """Build a domain to filter lines that need to be recomputed"""
         # Todo: check if tmp or fine
-        domain = [("carbon_origin_json", "=", False)]
+        domain = []
         if "all_states" not in force_compute:
             domain.append(
                 (
@@ -290,10 +290,12 @@ class CarbonLineMixin(models.AbstractModel):
     @api.model
     def _create_origin_lines(self):
         origin_vals_list = list()
-        lines_to_flush = self.search([("carbon_origin_json", "!=", False)])
+        lines_to_flush = self.filtered(
+            lambda line: line.carbon_origin_json is not False
+        )
 
         for line in lines_to_flush:
-            line.carbon_origin_ids.unlink()
+            line.carbon_origin_ids.write({"res_id": False})
             origin_vals_list.extend(line._get_line_origin_vals_list())
 
         # To avoid empty create calls
@@ -338,6 +340,9 @@ class CarbonLineMixin(models.AbstractModel):
 
     def action_recompute_carbon(self) -> dict:
         """Force re-computation of carbon values for lines"""
+        # maybe move clean_orphan_lines away once action_recompute_carbon
+        # is removed from tests. (why is it needed there?)
+        self.env["carbon.line.origin"]._clean_orphan_lines()
         skipped_lines = self._compute_carbon_debt(force_compute="all_states")
         if skipped_lines:
             return {

--- a/sustainability/models/carbon_line_origin.py
+++ b/sustainability/models/carbon_line_origin.py
@@ -190,22 +190,12 @@ class CarbonLineOrigin(models.Model):
             return self.env[self.res_model].browse(self.res_id).exists()
         raise ValueError(f"Model {self.res_model} not found")
 
-    @api.model
+    @api.autovacuum
     def _clean_orphan_lines(self):
         """
-        Extra-cleaning method to remove lines that have no origin
-        Mid-term goal is to deprecate it/remove it. The logger is here to help us doing this decision.
+        Cleaning method to remove lines that have no origin
         """
-        lines_to_remove = self.search([("res_id", "in", [0, False])])
-        if lines_to_remove:
-            _logger.warning(
-                "CarbonLineOrigin: %s lines will be removed because they have no origin",
-                len(lines_to_remove),
-            )
-            lines_to_remove.unlink()
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        res = super().create(vals_list)
-        self._clean_orphan_lines()
-        return res
+        lines_to_remove = self.env["carbon.line.origin"].search(
+            [("res_id", "in", [0, False])]
+        )
+        lines_to_remove.unlink()

--- a/sustainability/models/carbon_mixin.py
+++ b/sustainability/models/carbon_mixin.py
@@ -451,14 +451,6 @@ class CarbonMixin(models.AbstractModel):
     #                   ACTIONS
     # --------------------------------------------
 
-    def action_recompute_carbon(self, carbon_type: str = None):
-        carbon_type = carbon_type or self.env.context.get("carbon_type", "carbon_in")
-        if not hasattr(self, f"{carbon_type}_value"):
-            return False
-
-        getattr(self, f"_compute_{carbon_type}_mode")()
-        return True
-
     # def action_see_carbon_origin(self):
     #     """
     #     Pass `carbon_type` in context to ask for a value origin (e.g. 'carbon_value' will show 'carbon_value_origin' to user)

--- a/sustainability_hr_expense_report/models/hr_expense.py
+++ b/sustainability_hr_expense_report/models/hr_expense.py
@@ -23,8 +23,8 @@ class HrExpense(models.Model):
             line.carbon_balance = line.carbon_debit - line.carbon_credit
 
     @api.depends(
-        "account_id.carbon_in_factor_id",
-        "product_id.carbon_in_factor_id",
+        "account_id",
+        "product_id",
         "quantity",
         "total_amount",
         "date",

--- a/sustainability_purchase/models/purchase_order_line.py
+++ b/sustainability_purchase/models/purchase_order_line.py
@@ -53,13 +53,8 @@ class PurchaseOrderLine(models.Model):
     # --------------------------------------------
 
     @api.depends(
-        # Seller
-        "product_id.seller_ids",
-        "product_id.seller_ids.carbon_in_factor_id",
-        "order_id.partner_id",
         "partner_id",
-        # Product
-        "product_id.carbon_in_factor_id",
+        "product_id",
         "product_qty",
         "product_uom",
         "price_subtotal",
@@ -130,9 +125,3 @@ class PurchaseOrderLine(models.Model):
     def get_carbon_supplier_id_carbon_compute_values(self) -> dict:
         self.ensure_one()
         return self.get_product_id_carbon_compute_values()
-
-    @api.model
-    def create(self, vals):
-        lines = super().create(vals)
-        lines.action_recompute_carbon()
-        return lines


### PR DESCRIPTION
- remove depends : we don't want to trigger the method on all the record history when changing a carbon factor on a product or partner
- use autovacuum to remove orphan carbon.line.origin
- avoid unlink in _create_origin_lines (fix invalidate cache issue on write)
- filter instead of search