### PR TITLE
[FIX] sustainability,*_purchase: fix autosave

### DIFF
--- a/sustainability/views/account_account.xml
+++ b/sustainability/views/account_account.xml
@@ -26,6 +26,7 @@
                                     nolabel="1"
                                     style="margin-left: 8px;"
                                     widget="boolean_toggle"
+                                    options="{'autosave': False}"
                                 />
                                 <field invisible="1" name="carbon_in_mode" />
                                 <div

--- a/sustainability/views/product_category.xml
+++ b/sustainability/views/product_category.xml
@@ -26,6 +26,7 @@
                                     nolabel="1"
                                     style="margin-left: 8px;"
                                     widget="boolean_toggle"
+                                    options="{'autosave': False}"
                                 />
                                 <field invisible="1" name="carbon_in_mode" />
                                 <div
@@ -66,6 +67,7 @@
                                     nolabel="1"
                                     style="margin-left: 8px;"
                                     widget="boolean_toggle"
+                                    options="{'autosave': False}"
                                 />
                                 <field invisible="1" name="carbon_out_mode" />
                                 <div

--- a/sustainability/views/product_template.xml
+++ b/sustainability/views/product_template.xml
@@ -29,6 +29,7 @@
                                     nolabel="1"
                                     style="margin-left: 8px;"
                                     widget="boolean_toggle"
+                                    options="{'autosave': False}"
                                 />
                                 <field invisible="1" name="carbon_in_mode" />
                                 <div
@@ -69,6 +70,7 @@
                                     nolabel="1"
                                     style="margin-left: 8px;"
                                     widget="boolean_toggle"
+                                    options="{'autosave': False}"
                                 />
                                 <field invisible="1" name="carbon_out_mode" />
                                 <div

--- a/sustainability/views/res_country.xml
+++ b/sustainability/views/res_country.xml
@@ -26,6 +26,7 @@
                                     nolabel="1"
                                     style="margin-left: 8px;"
                                     widget="boolean_toggle"
+                                    options="{'autosave': False}"
                                 />
                                 <field invisible="1" name="carbon_in_mode" />
                                 <div
@@ -66,6 +67,7 @@
                                     nolabel="1"
                                     style="margin-left: 8px;"
                                     widget="boolean_toggle"
+                                    options="{'autosave': False}"
                                 />
                                 <field invisible="1" name="carbon_out_mode" />
                                 <div

--- a/sustainability_purchase/views/purchase_supplierinfo.xml
+++ b/sustainability_purchase/views/purchase_supplierinfo.xml
@@ -25,7 +25,7 @@
                                     name="carbon_in_is_manual"
                                     nolabel="1"
                                     widget="boolean_toggle"
-                                    class=""
+                                    options="{'autosave': False}"
                                     style="margin-left: 8px;"
                                 />
                             <field name="carbon_in_mode" invisible="1" />

--- a/sustainability_purchase/views/res_partner.xml
+++ b/sustainability_purchase/views/res_partner.xml
@@ -30,7 +30,7 @@
                                     name="carbon_in_is_manual"
                                     nolabel="1"
                                     widget="boolean_toggle"
-                                    class=""
+                                    options="{'autosave': False}"
                                     style="margin-left: 8px;"
                                 />
                                 <field name="carbon_in_mode" invisible="1" />


### PR DESCRIPTION
## Description

In the edited views,
'carbon_in/out_factor_id' fields are required if 'carbon_in/out_is_manual' is checked.

This caused a problem because widget boolean_toggle auto saves by default. This means that as soon as you checked the boolean, the required error appeared.

Changed views are the following:
-partner
-country
-products
-account
-product category
-supplier info

## Related Issues

https://github.com/sustainability-suite/sustainability-odoo/issues/285

## Test Instructions

Go on edited views, toggle the boolean, save to see error, add an ef, save and checked the flow is not broken.

## Additional Notes
\