### PR TITLE
[FIX] sustainability: journal entry column invisible

### DIFF
--- a/sustainability/views/account_move.xml
+++ b/sustainability/views/account_move.xml
@@ -105,8 +105,12 @@
                         title="See CO2 value origin"
                         type="object"
                     />
-                    <field force_save="1" invisible="1" name="carbon_origin_json" />
-                    <field invisible="1" name="carbon_currency_id" />
+                    <field
+                        force_save="1"
+                        column_invisible="1"
+                        name="carbon_origin_json"
+                    />
+                    <field column_invisible="1" name="carbon_currency_id" />
                 </xpath>
                 <xpath
                     expr="//field[@name='line_ids']//form//field[@name='credit']"


### PR DESCRIPTION
Fix this:

![image](https://github.com/user-attachments/assets/e95f1e3d-7416-45e9-85ec-3d6fe5aef19d)

The carbon columns should not be visible in "Journal Entry" invoice tab
