### PR TITLE
[16.0][FW] Blacklist of some PRs from 17.0

### DIFF
--- a/.oca/oca-port/blacklist/sustainability_employee_commuting.json
+++ b/.oca/oca-port/blacklist/sustainability_employee_commuting.json
@@ -1,0 +1,9 @@
+{
+  "pull_requests": {
+    "orphaned_commits": "not relevant",
+    "sustainability-suite/sustainability-odoo#274": "remote work is not present in v16",
+    "sustainability-suite/sustainability-odoo#278": "already ported",
+    "sustainability-suite/sustainability-odoo#334": "this was a bug fix related to refactor of commuting made in remote work PR",
+    "sustainability-suite/sustainability-odoo#338": "related to blacklisted remote work PR"
+  }
+}


### PR DESCRIPTION
The following PRs have been blacklisted:
- #: not relevant
- #274: remote work is not present in v16
- #278: already ported
- #334: this was a bug fix related to refactor of commuting made in remote work PR
- #338: related to blacklisted remote work PR