### PR TITLE
[FIX] sustainability_employee_commuting: carbon origin is lost

### DIFF
--- a/sustainability/models/carbon_line_mixin.py
+++ b/sustainability/models/carbon_line_mixin.py
@@ -258,6 +258,9 @@ class CarbonLineMixin(models.AbstractModel):
             if not record.carbon_debt:
                 continue
 
+            if self.env.context.get("commuting_auto_compute", False):
+                continue
+
             computed_value = record._compute_single_carbon_debt()
 
             epsilon = 0.0001

--- a/sustainability_employee_commuting/models/res_company.py
+++ b/sustainability_employee_commuting/models/res_company.py
@@ -188,19 +188,25 @@ class ResCompany(models.Model):
         if mode not in valid_modes:
             raise ValueError(f"Invalid mode: {mode}. Expected one of {valid_modes}.")
 
-        account_move = self.env["account.move"].create(
-            {
-                "ref": ref,
-                "journal_id": journal_id,
-                "invoice_date": account_move_date.strftime("%Y-%m-%d"),
-                "date": account_move_date.strftime("%Y-%m-%d"),
-                "partner_id": self.partner_id.id,
-                "company_id": self.id,
-                "line_ids": aml_vals_list,
-                "move_type": "in_invoice",
-                f"is_employee_{mode}_carbon": True,
-                f"employee_{mode}_carbon_date": account_move_date.strftime("%Y-%m-%d"),
-            }
+        account_move = (
+            self.env["account.move"]
+            .with_context(commuting_auto_compute=True)
+            .create(
+                {
+                    "ref": ref,
+                    "journal_id": journal_id,
+                    "invoice_date": account_move_date.strftime("%Y-%m-%d"),
+                    "date": account_move_date.strftime("%Y-%m-%d"),
+                    "partner_id": self.partner_id.id,
+                    "company_id": self.id,
+                    "line_ids": aml_vals_list,
+                    "move_type": "in_invoice",
+                    f"is_employee_{mode}_carbon": True,
+                    f"employee_{mode}_carbon_date": account_move_date.strftime(
+                        "%Y-%m-%d"
+                    ),
+                }
+            )
         )
         return account_move
 


### PR DESCRIPTION
prevent inverse method to overwrite carbon origin when commuting create the invoice

Use context for easy fix.

Would be better to rework _inverse_carbon_debt maybe?
