### PR TITLE
[ADD] Implement action to recompute CO2 emissions on carbon.line.origin

### DIFF
--- a/sustainability/models/carbon_line_origin.py
+++ b/sustainability/models/carbon_line_origin.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 
 from odoo import api, fields, models
 
@@ -229,6 +230,15 @@ class CarbonLineOrigin(models.Model):
                 )
             else:
                 origin.quantity = move_line.quantity
+
+    def action_recompute_carbon(self):
+        model_to_ids = defaultdict(list)
+        for origin in self:
+            model_to_ids[origin.res_model].append(origin.res_id)
+
+        for model, ids in model_to_ids.items():
+            records = self.env[model].browse(ids)
+            records.action_recompute_carbon()
 
     def get_record(self):
         """Return the record that generated this origin"""

--- a/sustainability/views/carbon_line_origin.xml
+++ b/sustainability/views/carbon_line_origin.xml
@@ -306,5 +306,19 @@
             </field>
             <field name="context">{'search_default_posted': 1}</field>
         </record>
+
+        <record
+            id="action_recompute_carbon_carbon_line_origin"
+            model="ir.actions.server"
+        >
+            <field name="name">Re-compute CO2</field>
+            <field name="model_id" ref="sustainability.model_carbon_line_origin" />
+            <field
+                name="binding_model_id"
+                ref="sustainability.model_carbon_line_origin"
+            />
+            <field name="state">code</field>
+            <field name="code">action = records.action_recompute_carbon()</field>
+        </record>
     </data>
 </odoo>


### PR DESCRIPTION
A client asked for this feature: add back (like there was in v16) the possibility to recompute on carbon.line.origin -> useful when clicking on carbon factor's carbon.line.origin smart button.