### PR TITLE
[FIX] sustainability: filter orphaned product.supplierinfo in carbon factor compute

### DIFF
--- a/sustainability/models/carbon_factor.py
+++ b/sustainability/models/carbon_factor.py
@@ -232,7 +232,9 @@ class CarbonFactor(models.Model):
     def _compute_product_supplierinfo_ids(self):
         for factor in self:
             suppliers_ids = self._get_distribution_lines_res_ids("product.supplierinfo")
-            supplierinfo_ids = self.env["product.supplierinfo"].browse(suppliers_ids)
+            supplierinfo_ids = (
+                self.env["product.supplierinfo"].browse(suppliers_ids).exists()
+            )
             factor.product_supplierinfo_ids = self.env["product.product"].search(
                 [
                     (


### PR DESCRIPTION
When a product supplier info is deleted (for example, during data imports), its carbon distribution lines are not deleted with it. When opening an emission factor linked to one of these leftovers, the form crashes with "It seems the records with ID X cannot be found. They might have been deleted", even though the factor exists.

This fix just ignores those broken links when computing the linked products, so the factor opens normally.